### PR TITLE
Replace async command dependency

### DIFF
--- a/Cameca.CustomAnalysis.Utilities/Cameca.CustomAnalysis.Utilities.csproj
+++ b/Cameca.CustomAnalysis.Utilities/Cameca.CustomAnalysis.Utilities.csproj
@@ -26,9 +26,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AsyncAwaitBestPractices.MVVM" Version="6.0.4" />
 		<PackageReference Include="Cameca.CustomAnalysis.Interface" Version="2.0.0" />
 		<PackageReference Include="Cameca.Extensions.Controls" Version="1.1.0" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 		<PackageReference Include="Prism.Wpf" Version="8.1.97" />
 	</ItemGroup>

--- a/Cameca.CustomAnalysis.Utilities/Legacy/LegacyCustomAnalysisViewModelBase.cs
+++ b/Cameca.CustomAnalysis.Utilities/Legacy/LegacyCustomAnalysisViewModelBase.cs
@@ -4,8 +4,8 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using AsyncAwaitBestPractices.MVVM;
 using Cameca.CustomAnalysis.Interface;
+using CommunityToolkit.Mvvm.Input;
 
 namespace Cameca.CustomAnalysis.Utilities.Legacy;
 
@@ -17,7 +17,7 @@ public abstract class LegacyCustomAnalysisViewModelBase<TNode, TAnalysis, TOptio
 	protected readonly Func<IViewBuilder> ViewBuilderFactory;
 	protected bool OptionsChanged = false;
 
-	private readonly AsyncCommand _runCommand;
+	private readonly IAsyncRelayCommand _runCommand;
 	public ICommand RunCommand => _runCommand;
 
 	public ObservableCollection<object> Tabs { get; } = new();
@@ -37,7 +37,7 @@ public abstract class LegacyCustomAnalysisViewModelBase<TNode, TAnalysis, TOptio
 		: base(services)
 	{
 		ViewBuilderFactory = viewBuilderFactory;
-		_runCommand = new AsyncCommand(OnRun, RunCommandEnabled);
+		_runCommand = new AsyncRelayCommand(OnRun, RunCommandEnabled);
 	}
 
 	protected virtual async Task OnRun()
@@ -75,10 +75,10 @@ public abstract class LegacyCustomAnalysisViewModelBase<TNode, TAnalysis, TOptio
 	private void OptionsOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
 		OptionsChanged = true;
-		_runCommand.RaiseCanExecuteChanged();
+		_runCommand.NotifyCanExecuteChanged();
 	}
 
-	private bool RunCommandEnabled(object? _) => !Tabs.Any() || OptionsChanged;
+	private bool RunCommandEnabled() => !Tabs.Any() || OptionsChanged;
 
 	protected override void Dispose(bool disposing)
 	{


### PR DESCRIPTION
Replace AsyncAwaitBestPractices.MVVM with CommunityToolkit.Mvvm as it has Microsoft backing and is larger growing dependency than existing. Already have dependency on other CommunityToolkit dependency for high performance data structures. Consolidation reduces required vetting of dependencies.